### PR TITLE
fix: GitHub PR を取得した時キャッシュするようにする

### DIFF
--- a/src/components/BacklogIssueListPage.vue
+++ b/src/components/BacklogIssueListPage.vue
@@ -4,6 +4,7 @@ import { getGithubPullRequests } from '~/api/github'
 import BacklogIssueCard from '~/components/BacklogIssueCard.vue'
 import { getSlackMessages } from '~/api/slack'
 import { cacheStorage } from '~/logic'
+import type { BacklogIssue } from '~/types/backlog'
 
 defineProps({
   popup: {
@@ -56,8 +57,9 @@ function openOptionsPage() {
 const showGithubPullRequestList = ref(true)
 const showGithubPullRequestListToggle = ref(false)
 
-async function _getGithubPullRequests(keyword: string) {
-  const res = await getGithubPullRequests(keyword)
+async function _getGithubPullRequests(issue: BacklogIssue) {
+  const res = await getGithubPullRequests(issue.issueKey)
+  cacheStorage.value.githubPullRequests[issue.id] = res
   showGithubPullRequestListToggle.value = true
   return res
 }
@@ -134,9 +136,8 @@ async function _getGithubPullRequests(keyword: string) {
         />
         <GithubPullRequestListArea
           v-show="showGithubPullRequestList"
-          :issue="issue"
           :default-github-pull-requests="cacheStorage.githubPullRequests[issue.id] || []"
-          :get-github-pull-requests="_getGithubPullRequests"
+          :get-github-pull-requests="() => _getGithubPullRequests(issue)"
           :get-slack-messages="slackEnabled ? getSlackMessages : null"
           ml-6
         />

--- a/src/components/GithubPullRequestListArea.vue
+++ b/src/components/GithubPullRequestListArea.vue
@@ -1,19 +1,14 @@
 <script lang="ts" setup>
 import { defineProps } from 'vue'
-import type { BacklogIssue } from '~/types/backlog'
 import type { GithubPullRequest } from '~/types/github'
 import type { SlackMessage } from '~/types/slack'
 const props = defineProps({
-  issue: {
-    type: Object as PropType<BacklogIssue>,
-    required: true,
-  },
   defaultGithubPullRequests: {
     type: Array as PropType<GithubPullRequest[]>,
     default: () => [],
   },
   getGithubPullRequests: {
-    type: Function as PropType<(keyword: string) => Promise<GithubPullRequest[]>>,
+    type: Function as PropType<() => Promise<GithubPullRequest[]>>,
     required: true,
   },
   getSlackMessages: {
@@ -21,13 +16,13 @@ const props = defineProps({
     default: null,
   },
 })
-const { issue, getGithubPullRequests, defaultGithubPullRequests } = toRefs(props)
+const { getGithubPullRequests, defaultGithubPullRequests } = toRefs(props)
 
 const githubPullRequests = ref<GithubPullRequest[]>(defaultGithubPullRequests.value)
 
 onMounted(async () => {
   try {
-    githubPullRequests.value = await getGithubPullRequests.value(issue.value.issueKey)
+    githubPullRequests.value = await getGithubPullRequests.value()
   }
   catch (error) {
     console.error(error)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: `_getGithubPullRequests`関数のシグネチャを変更し、引数を`issue: BacklogIssue`に更新しました。
- New Feature: GitHubのプルリクエストを取得した後にキャッシュする機能を追加しました。
- Refactor: `GithubPullRequestListArea`コンポーネントの`issue`プロパティバインディングを削除し、`get-github-pull-requests`プロパティバインディングを更新しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->